### PR TITLE
Add python implementation for RDF2Vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ Page: https://ericdongyx.github.io/metapath2vec/m2v.html
 
 Paper: https://ub-madoc.bib.uni-mannheim.de/41307/1/Ristoski_RDF2Vec.pdf
 
-Code: http://data.dws.informatik.uni-mannheim.de/rdf2vec/
+Java + Python: http://data.dws.informatik.uni-mannheim.de/rdf2vec/
+
+Python: https://github.com/IBCNServices/pyRDF2Vec
 
 <hr>
 


### PR DESCRIPTION
This commit adds a python implementation of RDF2Vec (https://github.com/IBCNServices/pyRDF2Vec), as opposed to the original implementation which is written in both Java (to extract walks) and Python (to train a Word2Vec model).