### PR TITLE
adding Tile2Vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,3 +521,9 @@ Python : https://github.com/Hellisotherpeople/debate2vec
 
 <hr>
 
+
+**Tile2Vec**
+
+Paper : https://arxiv.org/pdf/1805.02855.pdf
+
+<hr>


### PR DESCRIPTION
Tile2Vec is a paper that converts satellite image tiles to vectors. Spatial data to vectors.